### PR TITLE
doc: fix typos and syntax highlighting

### DIFF
--- a/docs/docker-tsurugi_ja.md
+++ b/docs/docker-tsurugi_ja.md
@@ -1,6 +1,6 @@
 # Tsurugi Dockerユーザーガイド
 
-本書ではTsurugiのDockerイメージの利用方法について説明します。
+本文書ではTsurugiのDockerイメージの利用方法について説明します。
 
 ## Tsurugi Dockerイメージの概要
 
@@ -107,7 +107,7 @@ Dockerイメージをコンテナとして実行する際に、Tsurugiサーバ�
 
 ### Tsurugiのログレベル指定
 
-環境変数 `GLOG_xx`` 経由でログ設定を指定して起動します。
+環境変数 `GLOG_xx` 経由でログ設定を指定して起動します。
 
 ```sh
 $ docker container run -d -p 12345:12345 --name tsurugi -e GLOG_v=30 ghcr.io/project-tsurugi/tsurugidb

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -65,7 +65,7 @@ If you execute `install.sh` without any arguments, it will put Tsurugi under the
 ### Setting the `TSURUGI_HOME` environment variable
 
 After the Tsurugi installation is complete, please set the environment variable `TSURUGI_HOME` to the Tsurugi installation path.
-The following is an example of installing Tsurugi into `$HOME/tsurugi`.
+The following is an example of installing Tsurugi into `$HOME/opt/tsurugi`.
 
 ```sh
 export TSURUGI_HOME="$HOME/opt/tsurugi"
@@ -78,7 +78,7 @@ If you use them, set `TSURUGI_HOME` to your shell environment and so on.
 
 This section introduces commands that provide fundamental Tsurugi capabilities such as starting/stopping Tsurugi server, executing SQL against Tsurugi server, etc.
 
-The subsequent commands are located in the `bin` directory of the intall directory.
+The subsequent commands are located in the `bin` directory of the install directory.
 
 ### `tgctl` : Tsurugi server administration command
 
@@ -113,7 +113,7 @@ The `tgsql` command is a CLI tool for submitting queries to Tsurugi.
 Using this, you can connect to Tsurugi using one of the following connection protocols.
 
 - IPC connections: relatively fast, but only from the same computer as the Tsurugi server.
-- TCP connections: relatively slow, but can be connected to from a remote computer.
+- TCP connections: relatively slow, but can be connected from a remote computer.
 
 An example of using an IPC connection is described below:
 
@@ -130,7 +130,7 @@ tgsql>
 
 `tgsql>` prompt will appear, and you can enter any query here:
 
-```sh
+```sql
 tgsql> BEGIN;
 transaction started. option=[
   type: OCC
@@ -172,7 +172,7 @@ $ cat $TSURUGI_HOME/var/etc/tsurugi.ini
     ...
 ```
 
-After editing the settings, you will need to restart the Tsurugi server for the settings to take effect.
+After editing the settings, you need to restart the Tsurugi server for the settings to take effect.
 Please refer to the following for each setting item.
 
 - Configuration file parameters

--- a/docs/getting-started_ja.md
+++ b/docs/getting-started_ja.md
@@ -64,7 +64,7 @@ Install Directory: $HOME/opt/tsurugi-1.x.x
 ### 環境変数 `TSURUGI_HOME` の設定
 
 Tsurugiのインストールが完了したら、環境変数 `TSURUGI_HOME` にTsurugiのインストールパスを設定してください。
-以下は `$HOME/tsurugi` にTsurugiをインストールした場合の設定例です。
+以下は `$HOME/opt/tsurugi` にTsurugiをインストールした場合の設定例です。
 
 ```sh
 export TSURUGI_HOME="$HOME/opt/tsurugi"
@@ -90,7 +90,7 @@ $ $TSURUGI_HOME/bin/tgctl start
 successfully launched tsurugidb
 ```
 
-`tgctl status` でTsurugiサーバを状態を確認できます。
+`tgctl status` でTsurugiサーバの状態を確認できます。
 
 ```sh
 $ $TSURUGI_HOME/bin/tgctl status
@@ -128,7 +128,7 @@ tgsql>
 
 `tgsql>` プロンプトが表示されるので、ここに任意のクエリーを入力できます。
 
-```sh
+```sql
 tgsql> BEGIN;
 transaction started. option=[
   type: OCC


### PR DESCRIPTION
typo 修正と SQL を多く含む fenced code block の syntax を `sql` へ変更します。