### PR TITLE
build: enable to rerun install.sh when mpdecimal build fails

### DIFF
--- a/dist/install/install-server.sh
+++ b/dist/install/install-server.sh
@@ -13,6 +13,7 @@ else
     curl -OL https://www.bytereef.org/software/mpdecimal/releases/mpdecimal-2.5.1.tar.gz
     cd -
   fi
+  rm -fr build-mpdecimal
   mkdir build-mpdecimal
   cd build-mpdecimal
   tar xf ${TG_INSTALL_BASE_DIR}/third_party/mpdecimal-2.5.1.tar.gz


### PR DESCRIPTION
いろいろな環境でビルドを試した際に、mdecimal のビルドが失敗したことがありました。
そうすると mpdecimal を展開したものが残ってしまうので、
install.sh の実行をやり直しても mkdir でエラーになり進まなくなるという問題がありました。
その修正です。