### PR TITLE
make install.sh to reject invalid options

### DIFF
--- a/dist/install/install.sh
+++ b/dist/install/install.sh
@@ -8,21 +8,19 @@ while (( $# > 0 ))
 do
   if [[ "$1" =~ "--prefix=" ]]; then
     _INSTALL_PREFIX=${1#--prefix=}
-  fi
-  if [[ "$1" =~ "--buildtype=" ]]; then
+  elif [[ "$1" =~ "--buildtype=" ]]; then
     _BUILD_TYPE=${1#--buildtype=}
-  fi
-  if [[ "$1" =~ "--parallel=" ]]; then
+  elif [[ "$1" =~ "--parallel=" ]]; then
     _PARALLEL=${1#--parallel=}
-  fi
-  if [[ "$1" == "--symbolic" ]]; then
+  elif [[ "$1" == "--symbolic" ]]; then
     _SYMBOLIC=ON
-  fi
-  if [[ "$1" =~ "--skip=" ]]; then
+  elif [[ "$1" =~ "--skip=" ]]; then
     _SKIP=${1#--skip=}
-  fi
-  if [[ "$1" == "--verbose" ]]; then
+  elif [[ "$1" == "--verbose" ]]; then
     _VERBOSE=ON
+  else
+    echo "[ERROR] invalid option: $1" 1>&2
+    exit 1
   fi
   shift
 done


### PR DESCRIPTION
ユーザがオプション指定するつづりを間違えて install.sh を実行した時など、未知のオプションが渡ってきたときに、現在は無視されていますが、これをエラー終了すように変更する修正です。

```
$ ./install.sh --prefix=/home/ban/build/b --build_type=Debug
[ERROR] invalid option: --build_type=Debug
```