### PR TITLE
dist: modify installer for supporting Ubuntu 24.04

### DIFF
--- a/dist/install/apt-install.sh
+++ b/dist/install/apt-install.sh
@@ -27,7 +27,6 @@ apt-get install -y -V \
  libjemalloc-dev \
  libleveldb-dev \
  libmsgpack-dev \
- libmpdec-dev \
  libnuma-dev \
  libpq-dev \
  libprotobuf-dev \
@@ -40,6 +39,8 @@ apt-get install -y -V \
  protobuf-compiler \
  ninja-build \
  uuid-dev
+
+apt-get install -y -V libmpdec-dev || true
 
 curl -OL https://apache.jfrog.io/artifactory/arrow/"$(lsb_release --id --short | tr 'A-Z' 'a-z')/apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb"
 apt-get install -y -V ./apache-arrow-apt-source-latest-"$(lsb_release --codename --short).deb"

--- a/dist/install/apt-install.sh
+++ b/dist/install/apt-install.sh
@@ -45,7 +45,7 @@ apt-get install -y -V libmpdec-dev || true
 curl -OL https://apache.jfrog.io/artifactory/arrow/"$(lsb_release --id --short | tr 'A-Z' 'a-z')/apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb"
 apt-get install -y -V ./apache-arrow-apt-source-latest-"$(lsb_release --codename --short).deb"
 apt-get update -y
-apt-get install -y -V libparquet-dev=14.0.1-1 libparquet-glib-dev=14.0.1-1 libarrow-dev=14.0.1-1 libarrow-glib-dev=14.0.1-1 libarrow-acero-dev=14.0.1-1 gir1.2-parquet-1.0=14.0.1-1 gir1.2-arrow-1.0=14.0.1-1
+apt-get install -y -V libparquet-dev=16.0.0-1 libparquet-glib-dev=16.0.0-1 libarrow-dev=16.0.0-1 libarrow-glib-dev=16.0.0-1 libarrow-acero-dev=16.0.0-1 gir1.2-parquet-1.0=16.0.0-1 gir1.2-arrow-1.0=16.0.0-1
 rm -f ./apache-arrow-apt-source-latest-"$(lsb_release --codename --short).deb"
 
 echo "$(basename $0) successful."

--- a/dist/install/apt-install.sh
+++ b/dist/install/apt-install.sh
@@ -45,7 +45,7 @@ apt-get install -y -V libmpdec-dev || true
 curl -OL https://apache.jfrog.io/artifactory/arrow/"$(lsb_release --id --short | tr 'A-Z' 'a-z')/apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb"
 apt-get install -y -V ./apache-arrow-apt-source-latest-"$(lsb_release --codename --short).deb"
 apt-get update -y
-apt-get install -y -V libparquet-dev=16.0.0-1 libparquet-glib-dev=16.0.0-1 libarrow-dev=16.0.0-1 libarrow-glib-dev=16.0.0-1 libarrow-acero-dev=16.0.0-1 gir1.2-parquet-1.0=16.0.0-1 gir1.2-arrow-1.0=16.0.0-1
+apt-get install -y -V libparquet-dev=16.1.0-1 libparquet-glib-dev=16.1.0-1 libarrow-dev=16.1.0-1 libarrow-glib-dev=16.1.0-1 libarrow-acero-dev=16.1.0-1 gir1.2-parquet-1.0=16.1.0-1 gir1.2-arrow-1.0=16.1.0-1
 rm -f ./apache-arrow-apt-source-latest-"$(lsb_release --codename --short).deb"
 
 echo "$(basename $0) successful."


### PR DESCRIPTION
- ignore failure to install libmpdec-dev because libmpdec-dev has been removed in the apt repository for Ubuntu 24.04.
- bump arrow to 16.1.0 because there is no version before arrow 15 in the apt repository for Ubuntu 24.04.