### PR TITLE
docs: remove IS TRUE/FALSE operator from sql-features.md

### DIFF
--- a/docs/sql-features.md
+++ b/docs/sql-features.md
@@ -285,8 +285,6 @@ Limitation: `LIMIT` must be with `ORDER BY`.
   <value-expression> AND <value-expression>
   <value-expression> OR <value-expression>
   <value-expression> IS [NOT] NULL
-  <value-expression> IS [NOT] TRUE
-  <value-expression> IS [NOT] FALSE
 ```
 
 ### Character string expressions


### PR DESCRIPTION
IS [NOT] TRUE/FALSE is unsupported on BETA5. The doc change to remove related lines from sql-features.md. 