### PR TITLE
docs: reference of query binary operators like `UNION`.

### DIFF
--- a/docs/sql-features.md
+++ b/docs/sql-features.md
@@ -194,10 +194,6 @@ CC_EXCEPTION (SQL-04000: serialization failed transaction:TID-000000000000003b s
 
 ```txt
 <query-expression>:
-  <query>
-  <query> UNION [<set-quantifier>] <query>
-
-<query>:
   SELECT [<set-quantifier>] <select-element> [, ...]
       FROM <table-reference> [, ...]
       [WHERE <value-expression>]
@@ -206,6 +202,7 @@ CC_EXCEPTION (SQL-04000: serialization failed transaction:TID-000000000000003b s
       [ORDER BY <order-by-element> [, ...]]
       [LIMIT <integer>]
   TABLE <table-name>
+  <query-expression> UNION [<set-quantifier>] <query-expression>
 
 <set-quantifier>:
   ALL

--- a/docs/sql-features.md
+++ b/docs/sql-features.md
@@ -194,6 +194,10 @@ CC_EXCEPTION (SQL-04000: serialization failed transaction:TID-000000000000003b s
 
 ```txt
 <query-expression>:
+  <query>
+  <query> UNION [<set-quantifier>] <query>
+
+<query>:
   SELECT [<set-quantifier>] <select-element> [, ...]
       FROM <table-reference> [, ...]
       [WHERE <value-expression>]
@@ -238,6 +242,8 @@ CC_EXCEPTION (SQL-04000: serialization failed transaction:TID-000000000000003b s
 note:
 
 Limitation: `LIMIT` must be with `ORDER BY`.
+
+Limitation: In the current version, `ORDER BY` and `LIMIT` are does not work correctly if they are at the end of binary expressions of query like `UNION` operator. This limitation will be removed in the future.
 
 ## Value expressions
 
@@ -719,8 +725,6 @@ Note that delimited identifiers may not refer the some built-in functions, like 
 
 * Definitions
   * `GENERATED ALWAYS AS IDENTITY` (identity columns)
-* Queries
-  * `UNION ALL`
 * Expressions
   * `NULLIF`
   * `COALESCE`


### PR DESCRIPTION
This PR adds syntax rules of query binary operators (e.g., `UNION`) to the document SQL Feature list.