### PR TITLE
doc: reference of boolean tests.

### DIFF
--- a/docs/sql-features.md
+++ b/docs/sql-features.md
@@ -285,6 +285,9 @@ Limitation: `LIMIT` must be with `ORDER BY`.
   <value-expression> AND <value-expression>
   <value-expression> OR <value-expression>
   <value-expression> IS [NOT] NULL
+  <value-expression> IS [NOT] TRUE
+  <value-expression> IS [NOT] FALSE
+  <value-expression> IS [NOT] UNKNOWN
 ```
 
 ### Character string expressions


### PR DESCRIPTION
This PR adds syntax rules of extra boolean expressions like `x is {true, false, unknown}`  to the document SQL Feature list.