### PR TITLE
docs: reference of `BETWEEN` and `IN`.

### DIFF
--- a/docs/sql-features.md
+++ b/docs/sql-features.md
@@ -300,6 +300,7 @@ Limitation: `LIMIT` must be with `ORDER BY`.
   <value-expression> > <value-expression>
   <value-expression> >= <value-expression
   <value-expression> [NOT] BETWEEN [<between-type>] <value-expression> AND <value-expression>
+  <value-expression> [NOT] IN ( <value-expression> [, <value-expression> ...] )
 
 <between-type>:
   SYMMETRIC
@@ -703,7 +704,6 @@ Note that delimited identifiers may not refer the some built-in functions, like 
 * Queries
   * `LIMIT` clause without `ORDER BY` clause
 * Expressions
-  * `IN`
   * `CURRENT_DATE`
   * `CURRENT_TIME`
   * `CURRENT_TIMESTAMP`

--- a/docs/sql-features.md
+++ b/docs/sql-features.md
@@ -299,6 +299,11 @@ Limitation: `LIMIT` must be with `ORDER BY`.
   <value-expression> <= <value-expression>
   <value-expression> > <value-expression>
   <value-expression> >= <value-expression
+  <value-expression> [NOT] BETWEEN [<between-type>] <value-expression> AND <value-expression>
+
+<between-type>:
+  SYMMETRIC
+  ASYMMETRIC
 ```
 
 ### Boolean expressions
@@ -698,7 +703,6 @@ Note that delimited identifiers may not refer the some built-in functions, like 
 * Queries
   * `LIMIT` clause without `ORDER BY` clause
 * Expressions
-  * `BETWEEN`
   * `IN`
   * `CURRENT_DATE`
   * `CURRENT_TIME`


### PR DESCRIPTION
This PR adds syntax rules of `BETWEEN` and `IN` predicate to the document SQL Feature list.