### PR TITLE
docs: reference of `LIMIT` without restrictions.

### DIFF
--- a/docs/sql-features.md
+++ b/docs/sql-features.md
@@ -234,11 +234,6 @@ CC_EXCEPTION (SQL-04000: serialization failed transaction:TID-000000000000003b s
   <value-expression> DESC
 ```
 
-----
-note:
-
-Limitation: `LIMIT` must be with `ORDER BY`.
-
 ## Value expressions
 
 * [Primary expressions](#primary-expressions)
@@ -709,11 +704,6 @@ The `sql.lowercase_regular_identifier` does not affect to delimited identifiers 
 Note that delimited identifiers may not refer the some built-in functions, like `COUNT`.
 
 ## Planned features
-
-### Highest
-
-* Queries
-  * `LIMIT` clause without `ORDER BY` clause
 
 ### High
 


### PR DESCRIPTION
This PR removes restriction notes from syntax rules of `LIMIT` clause in the document SQL Feature list.