### PR TITLE
docs: reference of `INSERT INTO ~ DEFAULT VALUES`.

### DIFF
--- a/docs/sql-features.md
+++ b/docs/sql-features.md
@@ -147,6 +147,7 @@ see [Queries](#queries)
 <insert-source>:
   VALUES (<value-expression> [, ...]) [, ...]
   <query-expression>
+  DEFAULT VALUES
 ```
 
 * behavior of individual insert operations:


### PR DESCRIPTION
This PR removes restriction notes from syntax rules of `DEFAULT VALUES` clause in `INSERT` statement in the document SQL Feature list.