### PR TITLE
docs: reference of rest query set operators (`EXCEPT`, `INTERSECT`).

### DIFF
--- a/docs/sql-features.md
+++ b/docs/sql-features.md
@@ -203,6 +203,8 @@ CC_EXCEPTION (SQL-04000: serialization failed transaction:TID-000000000000003b s
       [LIMIT <integer>]
   TABLE <table-name>
   <query-expression> UNION [<set-quantifier>] <query-expression>
+  <query-expression> EXCEPT [DISTINCT] <query-expression>
+  <query-expression> INTERSECT [DISTINCT] <query-expression>
 
 <set-quantifier>:
   ALL


### PR DESCRIPTION
This PR adds syntax rules of rest of set operators (`EXCEPT`, `INTERSECT`) to the document SQL Feature list.
