### PR TITLE
docs: note of caution about null characters to store.

### DIFF
--- a/docs/sql-features.md
+++ b/docs/sql-features.md
@@ -449,6 +449,9 @@ note:
 
 Tsurugi internally handles `DECIMAL` as a floating point decimal number. In cast expressions, you can use DECIMAL with any number of digits by specifying `(CAST x as DECIMAL(*,*))`. On the other hand, the scale (`s`) is required when stored it into tables because it must be recorded as a fixed point number.
 
+Storing character strings containing null characters (`U+0000`) in `CHAR` or `VARCHAR` columns of a table is prohibited.
+Attempting to write such a string using `INSERT` or `UPDATE` statements will result in an error.
+
 The zone offset of `TIMESTAMP WITH TIME ZONE` refers the configuration parameter `zone_offset` in `[session]` section of `tsurugi.ini`.
 Values of that type are stored as UTC time internally in the database, and the conversion (from/to strings or local timestamps) will use the zone offset value above.
 We are planning to allow individual clients to specify the zone offset value in the future.


### PR DESCRIPTION
This PR adds note about strings containing null characters to store into `CHAR/VARCHAR` columns.