### PR TITLE
docs: reference of PostgreSQL-style cast.

### DIFF
--- a/docs/sql-features.md
+++ b/docs/sql-features.md
@@ -411,9 +411,15 @@ CC_EXCEPTION (SQL-04000: serialization failed transaction:TID-000000000000003b s
 ```txt
 <cast-expression>:
   CAST(<value-expression> AS <type>)
+  <value-expression> :: <type>
 ```
 
 * `<type>` - see [Types](#types) and [Conversions](#conversions)
+
+----
+note:
+
+`expression::type` is a PostgreSQL-style cast expression.
 
 ### Placeholders
 


### PR DESCRIPTION
This PR adds a syntax rule of PostgreSQL-style cast (`expr::type`) to SQL feature list.
Note that, this feature has been worked correct since `1.0.0-BETA5`.
 