### PR TITLE
dist: fix install.sh to work even if libdir is not "lib"

### DIFF
--- a/dist/install/install.sh
+++ b/dist/install/install.sh
@@ -114,6 +114,7 @@ if [[ ! ${TG_SKIP_INSTALL} == *"server"* ]]; then
 
   ${_SCRIPTS_DIR}/install-server.sh
 
+  mkdir -p "${TG_INSTALL_DIR}/lib"
   if [ -f "${TG_INSTALL_BASE_DIR}/.install/tsurugi-info.json" ]; then
     cp -a "${TG_INSTALL_BASE_DIR}/.install/tsurugi-info.json" "${TG_INSTALL_DIR}/lib"
   else

--- a/dist/install/install.sh
+++ b/dist/install/install.sh
@@ -52,7 +52,7 @@ source ${_SCRIPTS_DIR}/install-util.sh
 
 source ${_SCRIPTS_DIR}/install-env.sh ${TG_INSTALL_BASE_DIR}
 if [ -f "${TG_INSTALL_BASE_DIR}/.install/BUILDINFO.md" ]; then
-  cp -a "${TG_INSTALL_BASE_DIR}/.install/BUILDINFO.md" "${TG_INSTALL_BASE_DIR}"
+  cp -a "${TG_INSTALL_BASE_DIR}/.install/BUILDINFO.md" "${TG_INSTALL_BASE_DIR}/"
 else
   ${_SCRIPTS_DIR}/generate-buildinfo.sh > ${TG_INSTALL_BASE_DIR}/BUILDINFO.md
 fi
@@ -98,12 +98,12 @@ cat ${TG_INSTALL_BASE_DIR}/BUILDINFO.md
 echo "------------------------------------"
 
 mkdir -p "${TG_INSTALL_DIR}"
-cp --preserve=timestamps "${TG_INSTALL_BASE_DIR}/BUILDINFO.md" ${TG_INSTALL_DIR}
+cp --preserve=timestamps "${TG_INSTALL_BASE_DIR}/BUILDINFO.md" ${TG_INSTALL_DIR}/
 
 if [[ ! ${TG_SKIP_INSTALL} == *"server"* ]]; then
   if "${MAKE_TSURUGI_BASE}"; then
     mkdir -p "${TSURUGI_BASE}/etc"
-    cp --preserve=timestamps "${_SCRIPTS_DIR}/conf/tsurugi.ini" ${TSURUGI_BASE}/etc
+    cp --preserve=timestamps "${_SCRIPTS_DIR}/conf/tsurugi.ini" ${TSURUGI_BASE}/etc/
     replace_config "${TSURUGI_BASE}/etc/tsurugi.ini" zone_offset="$(date +%:z),${_REPLACE_CONFIG}"
 
     mkdir -p "${TSURUGI_BASE}/data"
@@ -116,7 +116,7 @@ if [[ ! ${TG_SKIP_INSTALL} == *"server"* ]]; then
 
   mkdir -p "${TG_INSTALL_DIR}/lib"
   if [ -f "${TG_INSTALL_BASE_DIR}/.install/tsurugi-info.json" ]; then
-    cp -a "${TG_INSTALL_BASE_DIR}/.install/tsurugi-info.json" "${TG_INSTALL_DIR}/lib"
+    cp -a "${TG_INSTALL_BASE_DIR}/.install/tsurugi-info.json" "${TG_INSTALL_DIR}/lib/"
   else
     ${_SCRIPTS_DIR}/generate-tsurugi-info.sh > "${TG_INSTALL_DIR}/lib/tsurugi-info.json"
   fi


### PR DESCRIPTION
Tsurugi が主にサポートしている Ubuntu では、インストールディレクトリの下に `lib` ディレクトリを作成し、そこに共有ライブラリファイルを配置しますが、
RHEL 派生 Linux ディストリビューション等では、これが `lib64` ディレクトリとなり、サーバインストール時に `lib` ディレクトリを作成しませんが、
インストールスクリプトが `lib` ディレクトリがある前提で記述されているためファイルコピーが失敗します。

関連案件: project-tsurugi/tsurugi-issues#1066

この問題に対処する修正です。
ファイルコピーが失敗するときに、 cp コマンドがエラーにならず `lib` という名前のファイルとしてコピーしてしまい、より後段でエラーとなります。この問題に気づきやすくするように、 cp コマンドでコピー先の指定がディレクトリでないときにはそこでエラーとするような変更も入れてあります。
