### PR TITLE
explicitly install JSON library package that is installed transitively from Arrow package

### DIFF
--- a/dist/install/apt-install.sh
+++ b/dist/install/apt-install.sh
@@ -34,6 +34,7 @@ apt-get install -y -V \
  libssl-dev \
  libtbb-dev \
  lsb-release \
+ nlohmann-json3-dev \
  openjdk-17-jdk-headless \
  pkg-config \
  protobuf-compiler \

--- a/dist/install/dnf-install.sh
+++ b/dist/install/dnf-install.sh
@@ -19,6 +19,7 @@ dnf install -y \
  icu \
  java-17-openjdk-headless \
  jemalloc-devel \
+ json-devel \
  mpdecimal-devel \
  ninja-build \
  numactl-devel \


### PR DESCRIPTION
limestone が JSON処理に Debian/Ubuntu の nlohmann-json3-dev パッケージを使用していますが、
この開発パッケージは tsurugidb (jogasaki 由来) が依存している libarrow-dev パッケージからの推移的依存でインストールされるため、
tsurugidb ビルドに使用する (ビルド環境にインストールする) パッケージ一覧への追加をは省略していました。

しかし、明示的にインストール指定したほうが好ましいので、そのようにしました。
また、RHEL 互換ディストリビューション側も同様にしました。
