### PR TITLE
docs: add shirakami parallel recovery thread num setting

### DIFF
--- a/docs/config-parameters.md
+++ b/docs/config-parameters.md
@@ -28,6 +28,7 @@ Target component
 |---:| :---: | :--- |---|
 | `epoch_duration` | Integer | Length of the epoch (us). The default is 3000. |
 | `waiting_resolver_threads` | Integer | Number of threads that process the waiting and pre-commit of the LTXs in the waiting list. Default is 2. |
+| `index_restore_threads` | Integer | Number of threads that process index recovery from datastore on startup. Default is 4. |
 
 ## `sql` section
 


### PR DESCRIPTION
新しく増えた構成パラメータ (tsurugi.ini ファイル `[cc]` セクションの `index_restore_threads`) に関する説明の追加です。

関連: project-tsurugi/tsurugi-issues#1239