### PR TITLE
docs: add document about authentication and table privileges.

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -8,6 +8,8 @@
 * [Tsurugi Command Line Tools](./cli/README.md)
 * [Tsurugi Upgrade Guide](./upgrade-guide.md)
 * [Tsurugi Troubleshooting Guide](./troubleshooting-guide.md)
+* Tsurugi Authentication and Table Privileges
+  * [Tsurugi のユーザー認証とテーブル権限 (ja)](./auth-overview_ja.md)
 * [Service Message Version (SMV) Compatibility](./service-message-compatibilities.md)
 * [Error Code of Tsurugi Services](./error-code-tsurugi-services.md)
 * [Available SQL features in Tsurugi](./sql-features.md)

--- a/docs/auth-overview/architecture_ja.drawio.svg
+++ b/docs/auth-overview/architecture_ja.drawio.svg
@@ -1,0 +1,310 @@
+<svg host="65bd71144e" xmlns="http://www.w3.org/2000/svg" style="background: #ffffff; background-color: light-dark(#ffffff, #121212);" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="581px" height="421px" viewBox="-0.5 -0.5 581 421" content="&lt;mxfile&gt;&lt;diagram id=&quot;4HYe8cVHHO2aiGfcMrZr&quot; name=&quot;ページ1&quot;&gt;3Vldj9soFP01ltqHrcDYjvPofEyrqlVHykq7fWRixkHjmIiQSdJfXzDgj2BvrKmT7u7I0sAFruGccy/geGi+PX3keLf5ylKSez5ITx5aeL4PAxTIf8py1pbJZKoNGaep6VQbVvQH0cbQGA80JftWP8FYLuiubVyzoiBr0bJhztmx3e2Z5e2X7nBGHMNqjXPX+hdNxUZbY39S2z8Rmm3sm2FklveE1y8ZZ4fCvM/z0XP5p5u32PoC2rDf4JQdGya09NCcMyZ0aXuak1xBa1HT4x56Wqt5c1KIQQNiPeIV5wezdm+JvNj3El1A3nRiCklimmbQWGZza6n62MIM2aaw3Vk6BLVFgyDOFvgSOqImBzw0O26oIKsdXqvWo1SatG3ENpc1KIuvhAsqSUtymhXS9sSEYFvZkOL9pnSiepkFyr7k1IsSrLCXkiZsSwQ/yy6Vng1dRs1BbOrHWhwwMtrdNIRh+2Gjx6xyXXMiC4aWHorCborkM3F4eLAYT52m6f+JEL9NSEVQg5AgAi4hyB+BEd8h5DMR4nwj7G6gXxi5cFVabcIFwQhwoQ79xiqbxIuyEDdE6moT1fr1o1woMdFXWcxU8d0nzGnBXuh72ygn02j/NUrGQD66QL4rc/gdyEcjAB8MBb6RAmKLd/JgC3E7pctHUgHeecvAmy29ePb+3yv84BL+LuEHHfCPkrl7E/cUtpMysmg3hB936d2ODy031lESWEezgZEgTx47VSyYINdJqs813w4ipwUx9hTzl29yFBUKYfABhNK418c5H4xEYnw9hm6WvKKxNt8+/NdnCWdKOBpAgg6rL0/XWDEEwJGSWAQuCQjvR0DPAbUiQGrf5qVk3s5d8rG5Sya9nmgauOlcRpO7FX1ZJI9Dt6H/MPkI3DH6pg75j8nXXjRpIQgvcL4SjJcXvDdnNbV2qFJZeX8tSzdIZHeFEgIHy89JsurfZJKFDQJwucnIk8DQsLDO7LVyVkWkE3WDt657H+KQk/86DnHgRoc4CJ31kzQjK1MtmFJtc8HkRMXfjfL3cmMOTW1xMrCVlbOtFHJWatAfcgsv9/DSoofCydQa6tFlrTX8kXAqV0e4Meppq7n+M+xyaezA16QtU4F5RkTjHOuyw0mOBX1tu/8lqIM3Ql3D+72JbjfUsnIJVQW/cWSxh1dwfyPEyIUY3Qti9zL45/7ADxn9HXuk0vUzK4T5/gjjkS594fU8D7tuHXCMrxOw58g6xie9/kwMf8t1OuxCtus6HYwB7OQe6eGNqWDMFBy5+QHeLUG4Rz4X9SJN1Ed+lRxyvN/TtQppOV3hmsfaGIHX2hPDm2TmjsQMQTfwDcGHHXq3tsH8mDc8MnmIruMtvIg3ZL9pWBd69mZUzbLjKIJtR/7kwpFes+OolEu17C4FyWr9c4nuXv8khZY/AQ==&lt;/diagram&gt;&lt;/mxfile&gt;">
+    <defs/>
+    <rect fill="#ffffff" width="100%" height="100%" x="0" y="0" style="fill: light-dark(rgb(255, 255, 255), rgb(18, 18, 18));"/>
+    <g>
+        <g>
+            <rect x="20" y="340" width="165" height="80" fill="#ffffff" stroke="#000000" stroke-dasharray="3 3" pointer-events="all" style="fill: light-dark(#ffffff, var(--ge-dark-color, #121212)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
+        </g>
+        <g>
+            <g transform="translate(-0.5 -0.5)">
+                <switch>
+                    <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe flex-end; justify-content: unsafe center; width: 163px; height: 1px; padding-top: 417px; margin-left: 21px;">
+                            <div style="box-sizing: border-box; font-size: 0; text-align: center; color: #000000; ">
+                                <div style="display: inline-block; font-size: 12px; font-family: &quot;Helvetica&quot;; color: light-dark(#000000, #ffffff); line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
+                                    アプリケーションサーバー
+                                </div>
+                            </div>
+                        </div>
+                    </foreignObject>
+                    <text x="103" y="417" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="12px" text-anchor="middle">
+                        アプリケーションサーバー
+                    </text>
+                </switch>
+            </g>
+        </g>
+        <g>
+            <rect x="0" y="0" width="460" height="320" fill="#ffffff" stroke="#000000" stroke-dasharray="3 3" pointer-events="all" style="fill: light-dark(#ffffff, var(--ge-dark-color, #121212)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
+        </g>
+        <g>
+            <g transform="translate(-0.5 -0.5)">
+                <switch>
+                    <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe flex-end; justify-content: unsafe center; width: 458px; height: 1px; padding-top: 317px; margin-left: 1px;">
+                            <div style="box-sizing: border-box; font-size: 0; text-align: center; color: #000000; ">
+                                <div style="display: inline-block; font-size: 12px; font-family: &quot;Helvetica&quot;; color: light-dark(#000000, #ffffff); line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
+                                    データベースサーバー
+                                </div>
+                            </div>
+                        </div>
+                    </foreignObject>
+                    <text x="230" y="317" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="12px" text-anchor="middle">
+                        データベースサーバー
+                    </text>
+                </switch>
+            </g>
+        </g>
+        <g>
+            <rect x="20" y="20" width="280" height="100" fill="#ffffff" stroke="#000000" pointer-events="all" style="fill: light-dark(#ffffff, var(--ge-dark-color, #121212)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
+        </g>
+        <g>
+            <g transform="translate(-0.5 -0.5)">
+                <switch>
+                    <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe flex-end; justify-content: unsafe center; width: 278px; height: 1px; padding-top: 117px; margin-left: 21px;">
+                            <div style="box-sizing: border-box; font-size: 0; text-align: center; color: #000000; ">
+                                <div style="display: inline-block; font-size: 12px; font-family: &quot;Helvetica&quot;; color: light-dark(#000000, #ffffff); line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
+                                    Jetty
+                                </div>
+                            </div>
+                        </div>
+                    </foreignObject>
+                    <text x="160" y="117" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="12px" text-anchor="middle">
+                        Jetty
+                    </text>
+                </switch>
+            </g>
+        </g>
+        <g>
+            <rect x="40" y="40" width="120" height="60" fill="#ffffff" stroke="#000000" pointer-events="all" style="fill: light-dark(#ffffff, var(--ge-dark-color, #121212)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
+        </g>
+        <g>
+            <g transform="translate(-0.5 -0.5)">
+                <switch>
+                    <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 70px; margin-left: 41px;">
+                            <div style="box-sizing: border-box; font-size: 0; text-align: center; color: #000000; ">
+                                <div style="display: inline-block; font-size: 12px; font-family: &quot;Helvetica&quot;; color: light-dark(#000000, #ffffff); line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
+                                    認証サービス
+                                    <div>
+                                        (Harinoki)
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </foreignObject>
+                    <text x="100" y="74" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="12px" text-anchor="middle">
+                        認証サービス
+(Harinoki)
+                    </text>
+                </switch>
+            </g>
+        </g>
+        <g>
+            <rect x="340" y="20" width="240" height="280" fill="#ffffff" stroke="#000000" pointer-events="all" style="fill: light-dark(#ffffff, var(--ge-dark-color, #121212)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
+        </g>
+        <g>
+            <g transform="translate(-0.5 -0.5)">
+                <switch>
+                    <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe flex-end; justify-content: unsafe center; width: 238px; height: 1px; padding-top: 297px; margin-left: 341px;">
+                            <div style="box-sizing: border-box; font-size: 0; text-align: center; color: #000000; ">
+                                <div style="display: inline-block; font-size: 12px; font-family: &quot;Helvetica&quot;; color: light-dark(#000000, #ffffff); line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
+                                    認証バックエンド (例)
+                                </div>
+                            </div>
+                        </div>
+                    </foreignObject>
+                    <text x="460" y="297" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="12px" text-anchor="middle">
+                        認証バックエンド (例)
+                    </text>
+                </switch>
+            </g>
+        </g>
+        <g>
+            <path d="M 360 40 L 420 40 L 440 60 L 440 140 L 360 140 L 360 40 Z" fill="#ffffff" stroke="#000000" stroke-miterlimit="10" pointer-events="all" style="fill: light-dark(#ffffff, var(--ge-dark-color, #121212)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
+            <path d="M 420 40 L 420 60 L 440 60 Z" fill-opacity="0.05" fill="#000000" stroke="none" pointer-events="all" style="fill: light-dark(rgb(0, 0, 0), rgb(237, 237, 237));"/>
+            <path d="M 420 40 L 420 60 L 440 60" fill="none" stroke="#000000" stroke-miterlimit="10" pointer-events="all" style="stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
+        </g>
+        <g>
+            <g transform="translate(-0.5 -0.5)">
+                <switch>
+                    <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 78px; height: 1px; padding-top: 90px; margin-left: 361px;">
+                            <div style="box-sizing: border-box; font-size: 0; text-align: center; color: #000000; ">
+                                <div style="display: inline-block; font-size: 12px; font-family: &quot;Helvetica&quot;; color: light-dark(#000000, #ffffff); line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
+                                    パスワード
+                                    <div>
+                                        ファイル
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </foreignObject>
+                    <text x="400" y="94" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="12px" text-anchor="middle">
+                        パスワード
+ファイル
+                    </text>
+                </switch>
+            </g>
+        </g>
+        <g>
+            <path d="M 480 56 C 480 49.92 497.91 45 520 45 C 530.61 45 540.78 46.16 548.28 48.22 C 555.79 50.28 560 53.08 560 56 L 560 134 C 560 140.08 542.09 145 520 145 C 497.91 145 480 140.08 480 134 Z" fill="#ffffff" stroke="#000000" stroke-miterlimit="10" pointer-events="all" style="fill: light-dark(#ffffff, var(--ge-dark-color, #121212)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
+            <path d="M 560 56 C 560 62.08 542.09 67 520 67 C 497.91 67 480 62.08 480 56" fill="none" stroke="#000000" stroke-miterlimit="10" pointer-events="all" style="stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
+        </g>
+        <g>
+            <g transform="translate(-0.5 -0.5)">
+                <switch>
+                    <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 78px; height: 1px; padding-top: 105px; margin-left: 481px;">
+                            <div style="box-sizing: border-box; font-size: 0; text-align: center; color: #000000; ">
+                                <div style="display: inline-block; font-size: 12px; font-family: &quot;Helvetica&quot;; color: light-dark(#000000, #ffffff); line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
+                                    データベース
+                                </div>
+                            </div>
+                        </div>
+                    </foreignObject>
+                    <text x="520" y="108" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="12px" text-anchor="middle">
+                        データベース
+                    </text>
+                </switch>
+            </g>
+        </g>
+        <g>
+            <path d="M 480 171 C 480 164.92 497.91 160 520 160 C 530.61 160 540.78 161.16 548.28 163.22 C 555.79 165.28 560 168.08 560 171 L 560 249 C 560 255.08 542.09 260 520 260 C 497.91 260 480 255.08 480 249 Z" fill="#ffffff" stroke="#000000" stroke-miterlimit="10" pointer-events="all" style="fill: light-dark(#ffffff, var(--ge-dark-color, #121212)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
+            <path d="M 560 171 C 560 177.08 542.09 182 520 182 C 497.91 182 480 177.08 480 171" fill="none" stroke="#000000" stroke-miterlimit="10" pointer-events="all" style="stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
+        </g>
+        <g>
+            <g transform="translate(-0.5 -0.5)">
+                <switch>
+                    <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 78px; height: 1px; padding-top: 220px; margin-left: 481px;">
+                            <div style="box-sizing: border-box; font-size: 0; text-align: center; color: #000000; ">
+                                <div style="display: inline-block; font-size: 12px; font-family: &quot;Helvetica&quot;; color: light-dark(#000000, #ffffff); line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
+                                    ディレクトリ
+                                    <div>
+                                        サービス
+                                    </div>
+                                    <div>
+                                        (LDAP)
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </foreignObject>
+                    <text x="520" y="223" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="12px" text-anchor="middle">
+                        ディレクトリサービス(LDAP)...
+                    </text>
+                </switch>
+            </g>
+        </g>
+        <g>
+            <rect x="360" y="160" width="80" height="100" fill="#ffffff" stroke="#000000" pointer-events="all" style="fill: light-dark(#ffffff, var(--ge-dark-color, #121212)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
+            <path d="M 360 175 L 440 175" fill="none" stroke="#000000" stroke-miterlimit="10" pointer-events="all" style="stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
+            <path d="M 375 160 L 375 260" fill="none" stroke="#000000" stroke-miterlimit="10" pointer-events="all" style="stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
+        </g>
+        <g>
+            <g transform="translate(-0.5 -0.5)">
+                <switch>
+                    <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 78px; height: 1px; padding-top: 210px; margin-left: 361px;">
+                            <div style="box-sizing: border-box; font-size: 0; text-align: center; color: #000000; ">
+                                <div style="display: inline-block; font-size: 12px; font-family: &quot;Helvetica&quot;; color: light-dark(#000000, #ffffff); line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
+                                    PAM
+                                </div>
+                            </div>
+                        </div>
+                    </foreignObject>
+                    <text x="400" y="214" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="12px" text-anchor="middle">
+                        PAM
+                    </text>
+                </switch>
+            </g>
+        </g>
+        <g>
+            <rect x="180" y="40" width="100" height="60" fill="#ffffff" stroke="#000000" pointer-events="all" style="fill: light-dark(#ffffff, var(--ge-dark-color, #121212)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
+        </g>
+        <g>
+            <g transform="translate(-0.5 -0.5)">
+                <switch>
+                    <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 98px; height: 1px; padding-top: 70px; margin-left: 181px;">
+                            <div style="box-sizing: border-box; font-size: 0; text-align: center; color: #000000; ">
+                                <div style="display: inline-block; font-size: 12px; font-family: &quot;Helvetica&quot;; color: light-dark(#000000, #ffffff); line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
+                                    JAAS
+                                    <div>
+                                        ログイン
+                                    </div>
+                                    <div>
+                                        モジュール
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </foreignObject>
+                    <text x="230" y="74" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="12px" text-anchor="middle">
+                        JAAS...
+                    </text>
+                </switch>
+            </g>
+        </g>
+        <g>
+            <path d="M 280 70 L 332.43 70.11" fill="none" stroke="#000000" stroke-miterlimit="10" pointer-events="stroke" style="stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
+            <path d="M 337.68 70.12 L 330.67 73.6 L 332.43 70.11 L 330.69 66.6 Z" fill="#000000" stroke="#000000" stroke-miterlimit="10" pointer-events="all" style="fill: light-dark(rgb(0, 0, 0), rgb(255, 255, 255)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
+        </g>
+        <g>
+            <path d="M 100 160 L 100 106.37" fill="none" stroke="#000000" stroke-miterlimit="10" pointer-events="stroke" style="stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
+            <path d="M 100 101.12 L 103.5 108.12 L 100 106.37 L 96.5 108.12 Z" fill="#000000" stroke="#000000" stroke-miterlimit="10" pointer-events="all" style="fill: light-dark(rgb(0, 0, 0), rgb(255, 255, 255)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
+        </g>
+        <g>
+            <path d="M 30 169 C 30 164.03 61.34 160 100 160 C 118.57 160 136.37 160.95 149.5 162.64 C 162.63 164.32 170 166.61 170 169 L 170 271 C 170 275.97 138.66 280 100 280 C 61.34 280 30 275.97 30 271 Z" fill="#ffffff" stroke="#000000" stroke-miterlimit="10" pointer-events="all" style="fill: light-dark(#ffffff, var(--ge-dark-color, #121212)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
+            <path d="M 170 169 C 170 173.97 138.66 178 100 178 C 61.34 178 30 173.97 30 169" fill="none" stroke="#000000" stroke-miterlimit="10" pointer-events="all" style="stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
+        </g>
+        <g>
+            <g transform="translate(-0.5 -0.5)">
+                <switch>
+                    <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 138px; height: 1px; padding-top: 228px; margin-left: 31px;">
+                            <div style="box-sizing: border-box; font-size: 0; text-align: center; color: #000000; ">
+                                <div style="display: inline-block; font-size: 18px; font-family: &quot;Helvetica&quot;; color: light-dark(#000000, #ffffff); line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
+                                    Tsurugi
+                                </div>
+                            </div>
+                        </div>
+                    </foreignObject>
+                    <text x="100" y="233" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="18px" text-anchor="middle">
+                        Tsurugi
+                    </text>
+                </switch>
+            </g>
+        </g>
+        <g>
+            <rect x="40" y="360" width="120" height="40" rx="6" ry="6" fill="#ffffff" stroke="#000000" pointer-events="all" style="fill: light-dark(#ffffff, var(--ge-dark-color, #121212)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
+        </g>
+        <g>
+            <g transform="translate(-0.5 -0.5)">
+                <switch>
+                    <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 380px; margin-left: 41px;">
+                            <div style="box-sizing: border-box; font-size: 0; text-align: center; color: #000000; ">
+                                <div style="display: inline-block; font-size: 12px; font-family: &quot;Helvetica&quot;; color: light-dark(#000000, #ffffff); line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
+                                    アプリケーション
+                                </div>
+                            </div>
+                        </div>
+                    </foreignObject>
+                    <text x="100" y="384" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="12px" text-anchor="middle">
+                        アプリケーション
+                    </text>
+                </switch>
+            </g>
+        </g>
+        <g>
+            <path d="M 100 360 L 100 286.37" fill="none" stroke="#000000" stroke-miterlimit="10" pointer-events="stroke" style="stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
+            <path d="M 100 281.12 L 103.5 288.12 L 100 286.37 L 96.5 288.12 Z" fill="#000000" stroke="#000000" stroke-miterlimit="10" pointer-events="all" style="fill: light-dark(rgb(0, 0, 0), rgb(255, 255, 255)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
+        </g>
+        <g>
+            <path d="M 166.37 70 L 173.63 70" fill="none" stroke="#000000" stroke-miterlimit="10" pointer-events="stroke" style="stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
+            <path d="M 161.12 70 L 168.12 66.5 L 166.37 70 L 168.12 73.5 Z" fill="#000000" stroke="#000000" stroke-miterlimit="10" pointer-events="all" style="fill: light-dark(rgb(0, 0, 0), rgb(255, 255, 255)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
+            <path d="M 178.88 70 L 171.88 73.5 L 173.63 70 L 171.88 66.5 Z" fill="#000000" stroke="#000000" stroke-miterlimit="10" pointer-events="all" style="fill: light-dark(rgb(0, 0, 0), rgb(255, 255, 255)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
+        </g>
+    </g>
+    <switch>
+        <g requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility"/>
+        <a transform="translate(0,-5)" xlink:href="https://www.drawio.com/doc/faq/svg-export-text-problems" target="_blank">
+            <text text-anchor="middle" font-size="10px" x="50%" y="100%">
+                Text is not SVG - cannot display
+            </text>
+        </a>
+    </switch>
+</svg>

--- a/docs/auth-overview_ja.md
+++ b/docs/auth-overview_ja.md
@@ -1,0 +1,421 @@
+# Tsurugi のユーザー認証とテーブル権限
+
+[tsurugi.ini の設定一覧]:https://github.com/project-tsurugi/tsurugidb/blob/master/docs/config-parameters.md
+[tgctl]:https://github.com/project-tsurugi/tsurugidb/tree/master/docs/cli/tgctl_ja.md
+[tgctl credentials]:https://github.com/project-tsurugi/tsurugidb/tree/master/docs/cli/tgctl-credentials_ja.md
+[tgsql]:https://github.com/project-tsurugi/tsurugidb/tree/master/docs/cli/tgsql_ja.md
+[tgdump]:https://github.com/project-tsurugi/tsurugidb/tree/master/docs/cli/tgdump_ja.md
+[REST API 仕様]:https://github.com/project-tsurugi/harinoki/blob/master/docs/rest-api-ja.md
+[認証トークン仕様]:https://github.com/project-tsurugi/harinoki/blob/master/docs/token-ja.md
+[認証サーバーの起動設定]:https://github.com/project-tsurugi/harinoki/blob/master/docs/setting-ja.md
+[エラーコード]:https://github.com/project-tsurugi/tsurugidb/blob/master/docs/error-code-tsurugi-services.md
+[Jetty]:https://jetty.org/
+[JAAS]:https://jetty.org/docs/jetty/12/operations-guide/security/jaas-support.html
+
+Tsurugi 1.6.0 では、簡単なユーザー認証と、テーブル権限の制御の仕組みを導入しました。
+このドキュメントでは、その概要と設定方法について説明します。
+
+## ユーザー認証
+
+Tsurugi のユーザー認証は、Tsurugi に接続する際に資格情報 (ユーザー名やパスワードなど) を要求する仕組みです。
+認証機能を有効にした状態で、存在しないユーザーや誤ったパスワードを入力すると、Tsurugi への接続が拒否されます。
+
+```sh
+# tgsql に存在しないユーザー名を指定する例
+tgsql -c ipc:tsurugi --user no-such-user
+password: ****
+SCD-00201: authentication failed as the combination of user name and password is incorrect (Use `\connect` to connect)
+```
+
+なお、上記の `SCD-00201` は Tsurugi の[エラーコード]で、認証に失敗したことを示しています (`AUTHENTICATION_ERROR`)。
+
+## システム構成
+
+Tsurugi の認証機構は、以下のコンポーネントで構成されています:
+
+![認証機構のシステム構成図](auth-overview/architecture_ja.drawio.svg)
+
+* アプリケーション: Tsurugi に接続するクライアントアプリケーション
+* Tsurugi データベース: ユーザー認証を有効にした Tsurugi インスタンス
+* 認証サービス: 認証トークンを発行するサービス
+  * [Jetty] 内のウェブアプリケーションとして動作します
+* 認証バックエンド: 実際にユーザー名とパスワードを管理するコンポーネント群
+  * Jetty の標準の認証機構である、 [JAAS] を利用して認証を行います
+
+ユーザー認証は、主に以下の流れで行います (パスワード認証の例)。
+
+1. Tsurugi データベースは、システム起動時に認証サービスから公開鍵を取得します
+2. アプリケーションは、Tsurugi データベースに接続を試みる際、データベースから公開鍵を取得します
+3. アプリケーションは、ユーザー名とパスワードを公開鍵で暗号化し (暗号化資格情報) 、Tsurugi データベースに送信します
+4. Tsurugi データベースは、受け取った暗号化資格情報を認証サービスに送信します
+5. 認証サービスは、秘密鍵を利用して暗号化資格情報を復号し、ユーザー名とパスワードを取得します
+6. 認証サービスは、ユーザー名とパスワードを認証バックエンドに渡し、検証を行います
+7. 認証サービスは、認証に成功したら認証トークンを発行し、Tsurugi データベースに返します
+8. Tsurugi データベースは、認証トークンを受け取ったら、アプリケーションに接続を許可します
+
+上記のような構成で、アプリケーションは認証サービスと直接の通信を行わないため、認証サービスを外部に公開する必要はありません。
+
+## 認証サービスの設定
+
+なお、認証サービスは Tsurugi データベースとは独立して起動や終了の制御を行う必要があります。
+以下は、認証サービスを起動、終了する例です:
+
+```sh
+# 認証サービスの起動
+$TSURUGI_HOME/bin/authentication-server start
+
+# 認証サービスの終了
+$TSURUGI_HOME/bin/authentication-server stop
+```
+
+また、標準のインストールでは、認証バックエンドとしてローカルのパスワードファイルを使用します。
+標準のパスワードファイル (`$TSURUGI_HOME/var/auth/etc/harinoki-users.props`) には、インストール直後は以下の内容が含まれます:
+
+```props
+tsurugi: password,harinoki-user
+```
+
+上記は、ユーザー名 `tsurugi` とパスワード `password` の組み合わせで認証を行う設定です。
+また、認証を行う realm には `harinoki-user` を指定します。
+
+このファイルに `ユーザー名: パスワード,harinoki-user` の行を追加することで、データベースに接続可能なユーザーを追加できます。
+以下は `admin` ユーザーを追加する例です。
+
+```props
+tsurugi: password,harinoki-user
+admin: p@ssw0rd,harinoki-user
+```
+
+認証サービスの詳細や設定方法については、 [認証サーバーの起動設定] を参照してください。
+
+## Tsurugi データベースの設定
+
+Tsurugi データベースは、デフォルトではユーザー認証が無効になっています。
+ユーザー認証を有効にするには、認証サービスを利用可能な状態にしたうえで、Tsurugi の構成定義ファイル (`tsurugi.ini`) の `[authentication]` セクションを以下のように設定します:
+
+```ini
+[authentication]
+enabled = true
+```
+
+上記では、ユーザー認証を有効にし、デフォルトの認証サービス `http://localhost:8080/harinoki` を利用して認証を行います。
+
+ユーザー認証を有効にして Tsurugi データベースを起動すると、接続時に資格情報の提供が必要になります。
+
+各種設定の詳細は、 [tsurugi.ini の設定一覧] の `[authentication]` セクションを参照してください。
+
+## 資格情報
+
+ユーザー認証を有効にした場合、Tsurugi へ接続する際にはユーザーの資格情報を提供する必要があります。
+資格情報には主に以下の種類があります:
+
+| 資格情報の種類 | 概要 |
+|----------------|------|
+| ユーザー名とパスワード | ユーザー名とパスワードの組み合わせで認証を行います |
+| 暗号化資格情報 | 暗号化したユーザー名とパスワードの情報を使用して認証を行います |
+| 認証トークン | 認証サービスから発行されるトークンを使用して認証を行います |
+
+以降では、各資格情報の詳細と、Tsurugi の各種ツールでの使用方法について説明します。
+
+### 暗号化資格情報
+
+暗号化資格情報は、ユーザー名とパスワードを暗号化した形式で保存し、認証時に使用する方法です。
+平文でユーザー名とパスワードを保存することなく、安全に Tsurugi を利用できます。
+
+暗号化資格情報を作成するには、以下のコマンドを実行します:
+
+```sh
+tgctl credentials
+```
+
+上記のコマンドを実行すると、対話形式でユーザー名とパスワードの入力を求められます。
+これらを入力すると、暗号化された資格情報 `~/.tsurugidb/credentials.key` が生成されます。
+
+>[!IMPORTANT]
+> 資格情報の作成には、認証機能を有効化した Tsurugi データベースが稼働中である必要があります。
+
+なお、オプションを指定しない場合、この資格情報は 90 日間有効です。
+有効期限を変更するには、 `--expiration <days>` オプションを使用します (例: `--expiration 30`)。
+
+暗号化資格情報の作成について、詳しくは [tgctl credentials] のドキュメントを参照してください。
+
+>[!NOTE]
+> 内部的には、ユーザー名とパスワードを直接入力して Tsurugi と接続した際にも、
+> 一時的に上記と同様の暗号化資格情報を生成してそれを Tsurugi データベースに送信しています。
+> `tgctl credentials` コマンドは、その暗号化資格情報をあらかじめ作成し、保存するためのものです。
+
+### 認証トークン
+
+認証トークンは認証サービスが発行するトークンで、Tsurugi への接続時に利用できます。
+これは主に、Tsurugi と連携するサービス (例: Belayer) のために設計されており、通常はユーザーが直接利用するケースはありません。
+
+認証トークンを取得するには、認証サービスの REST API (`/issue`) を使用します:
+
+```sh
+curl -u tsurugi:password http://localhost:8080/harinoki/issue
+```
+
+上記は `http://localhost:8080/harinoki` で稼働している認証サービスから、ユーザー `tsurugi` のトークンを取得する例です。
+実行すると、以下のような JSON レスポンスが返されます (一部省略):
+
+```json
+{"type":"ok","token":"..."}
+```
+
+実際には、 `token` フィールドに含まれる長い文字列が認証トークンです。
+
+認証サービスの REST API や、認証トークンの詳細については、それぞれ以下を参照してください。
+
+* [REST API 仕様]
+* [認証トークン仕様]
+
+### CLI の認証オプション
+
+Tsurugi の各種 CLI ツールでは、以下のオプションを使用して認証機能を利用できます:
+
+| オプション | 説明 |
+|------------|------|
+| `--user <username>` | オプションにユーザー名、プロンプトでパスワードを入力し、認証を行います。 |
+| `--credentials <file>` | 指定したファイルから暗号化資格情報を読み込み、認証を行います。 |
+| `--auth-token <token>` | 指定した認証トークンを使用して認証を行います。 |
+| `--no-auth` | 資格情報を使用せずに、ログインを試みます (認証機能が無効な場合にのみ有効)。 |
+
+上記のオプションがいずれも指定されなかった場合、以下の手順で認証を試みます:
+
+1. 環境変数 `TSURUGI_AUTH_TOKEN` が設定されている場合、その値を認証トークンとして使用します
+2. `~/.tsurugidb/credentials.key` が存在する場合、そのファイルを暗号化資格情報として使用します
+3. ユーザー名とパスワードを対話的に入力し、認証を行います
+
+以下は、SQL コンソールに接続する際の例です:
+
+```sh
+$ tgsql -c ipc:tsurugi --user tsurugi
+[main] INFO com.tsurugidb.tgsql.core.TgsqlRunner - establishing connection: ipc:tsurugi
+password: ********
+[main] INFO com.tsurugidb.tgsql.core.TgsqlRunner - start repl
+tgsql>
+```
+
+それぞれの CLI ツールについて、詳細は以下を参照してください:
+
+* [tgctl]
+* [tgsql]
+* [tgdump]
+
+### Tsubakuro (Java)
+
+Tsurugi の Java クライアントライブラリである Tsubakuro から、資格情報を指定して Tsurugi に接続するには以下のように書きます:
+
+```java
+Credential credential = new UsernamePasswordCredential("tsurugi", "password");
+Session session = SessionBuilder.connect("ipc:tsurugi")
+    .withCredential(credential)
+    .create();
+```
+
+上記では、 [`SessionBuilder`](https://github.com/project-tsurugi/tsubakuro/blob/master/modules/session/src/main/java/com/tsurugidb/tsubakuro/common/SessionBuilder.java) を利用してセッションを構築する際に、 `withCredential` メソッドを使用して資格情報を指定しています。
+資格情報を表す [Credential](https://github.com/project-tsurugi/tsubakuro/blob/master/modules/common/src/main/java/com/tsurugidb/tsubakuro/channel/common/connection/Credential.java) インターフェースには、以下の種類の実装があります:
+
+| クラス | CLI との対応 | 説明 |
+|-------|------|------|
+| [`UsernamePasswordCredential`](https://github.com/project-tsurugi/tsubakuro/blob/master/modules/common/src/main/java/com/tsurugidb/tsubakuro/channel/common/connection/UsernamePasswordCredential.java) | `--user` | ユーザー名とパスワードを使用して認証を行います。 |
+| [`RememberMeCredential`](https://github.com/project-tsurugi/tsubakuro/blob/master/modules/common/src/main/java/com/tsurugidb/tsubakuro/channel/common/connection/RememberMeCredential.java) | `--auth-token` | 認証トークンを使用して認証を行います。 |
+| [`FileCredential`](https://github.com/project-tsurugi/tsubakuro/blob/master/modules/common/src/main/java/com/tsurugidb/tsubakuro/channel/common/connection/FileCredential.java) | `--credentials` | 暗号化資格情報を使用して認証を行います。 |
+| [`NullCredential`](https://github.com/project-tsurugi/tsubakuro/blob/master/modules/common/src/main/java/com/tsurugidb/tsubakuro/channel/common/connection/NullCredential.java) | `--no-auth` | 資格情報を使用せずに接続を試みます (認証機能が無効な場合にのみ有効)。 |
+
+### Iceaxe (Java)
+
+Iceaxe は Tsubakuro をラップし、より高レベルな API を提供するライブラリです。
+Iceaxe から Tsurugi に接続する際も、Tsubakuro と同様に資格情報を指定できます:
+
+```java
+Credential credential = new UsernamePasswordCredential("tsurugi", "password");
+TsurugiConnector connector = TsurugiConnector.of("ipc:tsurugi", credential);
+try (TsurugiSession session = connector.createSession(credential)) {
+    // ...
+}
+```
+
+なお、Iceaxe と Tsubakuro では、共通の資格情報 ([Credential](https://github.com/project-tsurugi/tsubakuro/blob/master/modules/common/src/main/java/com/tsurugidb/tsubakuro/channel/common/connection/Credential.java) インターフェース) を利用可能です。
+
+### Tsubakuro/Rust
+
+Tsubakuro/Rust (Rust 版の Tsubakuro) でも、Java と類似の方法で資格情報を使用できます。
+
+```rust
+let credential = Credential::from_user_password("tsurugi", Some("password"));
+let mut connection_option = ConnectionOption::new();
+connection_option.set_endpoint_url("tcp://localhost:12345")?;
+connection_option.set_credential(credential);
+let session = Session::connect(&connection_option).await?;
+```
+
+資格情報を表す [Credential](https://github.com/project-tsurugi/tsubakuro-rust/blob/master/tsubakuro-rust-core/src/session/credential.rs) 列挙型には、以下の種類の実装があります:
+
+| 列挙子 | 作成メソッド | CLI との対応 | 説明 |
+|-------|-------------|------|------|
+| `UserPassword` | `from_user_password` | `--user` | ユーザー名とパスワードを使用して認証を行います。 |
+| `AuthToken` | `from_auth_token` | `--auth-token` | 認証トークンを使用して認証を行います。 |
+| `File` | `load` | `--credentials` | 暗号化資格情報を使用して認証を行います。 |
+| `Null` | `null` | `--no-auth` | 資格情報を使用せずに接続を試みます (認証機能が無効な場合にのみ有効)。 |
+
+### Tsurugi ODBC ドライバー
+
+Tsurugi ODBC ドライバー APIを使用して Tsurugi に接続する場合、接続文字列に資格情報を指定できます。詳細は、以下のドキュメントを参照してください:
+- [Tsurugi ODBCドライバー 使用方法](https://github.com/project-tsurugi/tsubakuro-rust/blob/master/tsubakuro-rust-odbc/docs/usage_ja.md)
+
+また、Windows 版のODBC ドライバーでは、ODBC データソース アドミニストレーターで資格情報を含むデータソースを設定できます。詳細は、以下のドキュメントを参照してください:
+- [Tsurugi ODBCドライバー インストール方法](https://github.com/project-tsurugi/tsubakuro-rust/blob/master/tsubakuro-rust-odbc/docs/install_ja.md)
+
+## システム管理者の設定
+
+システム管理者は、Tsurugi データベースのすべての操作を実行できる特別なユーザーです。
+Tsurugi のデフォルトの設定では、 **すべてのユーザーがシステム管理者** として登録されています。
+
+システム管理者を制限するには、Tsurugi の構成定義ファイル (`tsurugi.ini`) の `[authentication]` セクションに以下の設定を追加します:
+
+```ini
+[authentication]
+...
+administrators = tsurugi, admin
+```
+
+上記のようにカンマ (`,`) 区切りでユーザー名を指定することで、システム管理者を `tsurugi` と `admin` の 2 ユーザーに制限できます。
+設定の詳細は、 [tsurugi.ini の設定一覧] の `[authentication]` セクションを参照してください。
+
+システム管理者でないユーザー (以下、一般ユーザー) は、主に以下の制限を受けます:
+
+| 操作 | 制限 |
+| ---- | ---- |
+| データベースの起動・終了 | 制限はありません (*1) |
+| バックアップの作成・復元 | 一般ユーザーは利用できません |
+| セッションの制御 | 当該ユーザーが所有するセッションのみ表示や収量が可能です |
+| テーブルの操作 | 個別の[テーブル権限](#テーブル権限の制御)によって制御されます |
+
+*1: Tsurugi 1.6.0 での暫定的な仕様です。将来的に制限される可能性があります。
+
+より詳細な情報については、[tgctl] のドキュメントや、次節の[テーブル権限の制御](#テーブル権限の制御)を参照してください。
+
+## テーブル権限の制御
+
+Tsurugi の一般ユーザーは、デフォルトではテーブルの読み書きが行えません。
+読み書きを行うためには、システム管理者がテーブルを作成し、一般ユーザーに対してそのテーブルに対する権限を付与する必要があります。
+
+### テーブル権限の付与
+
+一般ユーザーにテーブル操作の権限を付与するには、 `GRANT` 文を使用します。
+以下は、システム管理者がテーブルを作成し、一般ユーザーに対して読み取り (`SELECT`) と行の追加 (`INSERT`) の権限を付与する例です:
+
+```sql
+-- システム管理者で実行
+CREATE TABLE t1 (id INT, name VARCHAR(*));
+
+-- テーブル t1 に対して、一般ユーザー user1 に SELECT, INSERT 権限を付与
+GRANT SELECT, INSERT ON t1 TO user1;
+```
+
+また、特別な権限として `ALL PRIVILEGES` があります。
+これは、対象テーブルに対して管理者と同等のすべての権限を付与します:
+
+```sql
+GRANT ALL PRIVILEGES ON t1 TO user1;
+```
+
+以下は、権限の一覧と、その権限が許可する操作の例です:
+
+| 操作内容 | `ALL PRIVILEGES` | `SELECT` | `INSERT` | `UPDATE` | `DELETE` |
+|----------|:----------------:|:--------:|:-------:|:-------:|:-------:|
+| メタデータの取得 | o | o | o | o | o |
+| 行の読み取り | o | o |   |   |   |
+| 行の追加 | o |   | o |   |   |
+| 行の更新 | o |   |   | o*1 |   |
+| 行の削除 | o |   |   |   | o*2 |
+| テーブルの作成 |  |  |  |  |  |
+| テーブルの削除 | o | |  |  |  |
+| インデックスの作成 | o |  |  |  |  |
+| インデックスの削除 | o |  |  |  |  |
+| 権限の制御 | o |  |  |  |  |
+
+*1: 行の更新 (`UPDATE` 文の実行) には、 `UPDATE` 権限のほかに `SELECT` 権限も必要です。
+
+*2: 行の削除 (`DELETE` 文の実行) には、 `DELETE` 権限のほかに `SELECT` 権限も必要です。
+
+メタデータの取得の権限は、テーブル一覧の取得、テーブルメタデータの取得、および `EXPLAIN` によるクエリプランの取得に必要です。
+当該権限を持っていない場合、テーブル一覧の取得を行った際に、対象のテーブルが結果に含まれません。
+なお、メタデータの権限は将来的に、個別の権限として独立させる予定です。
+
+また、一般ユーザーであっても、テーブル権限の制御に関する権限 (`ALL PRIVILEGES`) が付与されていれば、ほかの一般ユーザーに対して `GRANT` 文を実行できます。
+
+>[!NOTE]
+> Tsurugi 1.6.0 では、一般ユーザーはテーブルの作成を行えません。
+> 将来的に、スキーマの導入に伴い、スキーマにテーブル作成権限を付与することで、一般ユーザーでもテーブルを作成できるようになる予定です。
+
+>[!IMPORTANT]
+> Tsurugi 1.6.0 では、テーブルに付与された権限の一覧を確認する方法はありません。
+> 今後、情報スキーマ等の方法で確認方法を提供予定です。
+
+### テーブル権限の剥奪
+
+一般ユーザーに付与したテーブル操作の権限を剥奪するには、 `REVOKE` 文を使用します。
+以下は、一般ユーザー user1 からテーブル t1 に対する `INSERT`, `DELETE` 権限を剥奪する例です:
+
+```sql
+-- テーブル t1 に対して、一般ユーザー user1 から INSERT, DELETE 権限を剥奪
+REVOKE INSERT, DELETE ON t1 FROM user1;
+```
+
+また、テーブルに対するすべての権限を剥奪するには、 `ALL PRIVILEGES` を指定します:
+
+```sql
+-- テーブル t1 に対して、一般ユーザー user1 からすべての権限を剥奪
+REVOKE ALL PRIVILEGES ON t1 FROM user1;
+```
+
+注意すべき点として、 `ALL PRIVILEGES` の権限を付与したユーザーから、`SELECT`, `INSERT` などの個別の権限を剥奪することはできません。
+そのため、一度 `REVOKE ALL PRIVILEGES` を実行したうえで、必要な権限を再度 `GRANT` する必要があります。
+
+なお、 `REVOKE` 文の実行には、テーブル権限の制御に関する権限が必要です。
+そのため、システム管理者または `ALL PRIVILEGES` 権限を付与された一般ユーザーのみが `REVOKE` 文を実行できます。
+
+また、SQL標準外の機能として、ユーザー指定に関する拡張構文 `REVOKE ALL PRIVILEGES .. FROM *` , `REVOKE ALL PRIVILEGES .. FROM CURRENT_USER` をサポートしています。
+- `REVOKE ALL PRIVILEGES .. FROM *` は、これを実行したユーザーを除き、すべてのユーザーの権限を剥奪します。
+  - 後述する `PUBLIC` で付与したデフォルトの権限を含めて剥奪します。
+- `REVOKE ALL PRIVILEGES .. FROM CURRENT_USER` は、これを実行したユーザー自身の権限を剥奪します。
+
+### 全ユーザーに対するデフォルトの権限の制御
+
+`GRANT .. TO ...` でユーザー名に `PUBLIC` を指定すると、すべてのユーザーに対するデフォルトの権限を付与できます。
+
+```sql
+-- テーブル t1 に対して、すべてのユーザーに SELECT 権限を付与
+GRANT SELECT ON t1 TO PUBLIC;
+```
+
+デフォルトの権限が与えられたテーブルに対しては、個別の権限を持たない一般ユーザーであっても、当該権限に含まれる操作を行えます。
+例えば、上記であればすべての一般ユーザーはテーブル t1 に対して行の読み取りを行えます。
+
+また、すべてのユーザーに `SELECT` デフォルトの権限を付与したうえで、特定のユーザーに個別の権限を付与することも可能です。
+
+```sql
+-- テーブル t1 に対して、すべてのユーザーに SELECT 権限を付与
+GRANT SELECT ON t1 TO PUBLIC;
+
+-- テーブル t1 に対して、さらに一般ユーザー user1 に INSERT 権限を付与
+GRANT INSERT ON t1 TO user1;
+```
+
+上記の場合、一般ユーザー user1 はテーブル t1 に対して行の読み取りと追加を行えますが、ほかの一般ユーザーは行の読み取りのみ可能です。
+
+同様に、 `REVOKE .. FROM ...` でユーザー名に `PUBLIC` を指定すると、すべてのユーザーからデフォルトの権限を剥奪できます。
+
+```sql
+-- テーブル t1 に対して、すべてのユーザーから SELECT 権限を剥奪
+REVOKE SELECT ON t1 FROM PUBLIC;
+```
+
+上記は、すべての一般ユーザーから `SELECT` の権限を **剥奪するわけではありません** 。
+あくまで、デフォルトの権限を剥奪するのみであり、ユーザーに対して個別に `SELECT` 権限が付与されている場合、そのユーザーは引き続き `SELECT` 操作を行えます。
+
+>[!NOTE] `GRANT` , `REVOKE` 文の仕様についての詳細は、以下のドキュメントを参照してください:
+>  - [Available SQL features in Tsurugi - GRANT PRIVILEGE](https://github.com/project-tsurugi/tsurugidb/blob/master/docs/sql-features.md#grant-privilege)
+>  - [Available SQL features in Tsurugi - REVOKE PRIVILEGE](https://github.com/project-tsurugi/tsurugidb/blob/master/docs/sql-features.md#revoke-privilege)


### PR DESCRIPTION
This pull request adds new documentation to the project, specifically focusing on user authentication and table privileges in Tsurugi.

Documentation improvements:

* Added a new section titled "Tsurugi Authentication and Table Privileges" to the main documentation index in `docs/README.md`.
* Linked to a Japanese-language overview document, `auth-overview_ja.md`, under the new section for user authentication and table privileges.