### PR TITLE
build: improve around installing and detecting libmpdec++ dev package on newer Debian/Ubuntu

### DIFF
--- a/dist/install/apt-install.sh
+++ b/dist/install/apt-install.sh
@@ -48,7 +48,7 @@ apt-get install -y -V \
  ninja-build \
  uuid-dev
 
-apt-get install -y -V libmpdec-dev || true
+apt-get install -y -V '^libmpdec\+\+-dev$' || apt-get install -y -V libmpdec-dev || true
 
 curl --retry 3 --retry-all-errors -OL https://apache.jfrog.io/artifactory/arrow/"$(lsb_release --id --short | tr 'A-Z' 'a-z')/apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb"
 apt-get install -y -V ./apache-arrow-apt-source-latest-"$(lsb_release --codename --short).deb"

--- a/dist/install/install-server.sh
+++ b/dist/install/install-server.sh
@@ -5,7 +5,7 @@ if [ "${TG_VERBOSE_INSTALL}" = "ON" ]; then
   export VERBOSE=1
 fi
 
-if [ "${TG_FORCE_INSTALL_MPDECIMAL}" != "ON" ] && ldconfig -p | grep -F --quiet libmpdec++; then
+if [ "${TG_FORCE_INSTALL_MPDECIMAL}" != "ON" ] && /sbin/ldconfig -p | grep -F --quiet libmpdec++; then
   echo -e "\n[SKIPPED Install_mpdecimal]"
 else
   echo -e "\n[Install mpdecimal]"


### PR DESCRIPTION
Debian 13 では以前消された mpdecimal パッケージが復活しましたが、パッケージ構成が変わり、C++ 開発ライブラリは libmpdec-dev から libmpdec++-dev に移動しました。
Ubuntu 26.04 でも同様の構成になりそうです。
この変更に追従します。

関連案件: project-tsurugi/tsurugi-issues#1291

libmpdec++-dev を指定する際に `^libmpdec\+\+-dev$` と記述しているのは、 apt-get のパッケージ名指定の際に 正規表現のメタ文字が含まれていると特殊な挙動 (正規表現として部分一致) をするためです。

また Debian 固有の話で Ubuntu にはしばらく関係のない話かもしれませんが、非特権ユーザは /sbin, /usr/sbin に PATH を通さないため `ldconfig -p` が実行できないという問題があったため、フルパスで指定することにしました。
新しい Debian/Ubuntu では /sbin は /usr/sbin へのシンボリックリンクになっているため /usr/sbin/ldconfig のほうが好ましいかもしれませんが、古いシステムでは /sbin/ldconfig でないとアクセスできないことと、 /sbin が廃止されて消されることは当面なさそうということで /sbin/ldconfig のほうにしました。