### PR TITLE
update docs/config-parameters.md to refrect the previous commit

### DIFF
--- a/docs/config-parameters.md
+++ b/docs/config-parameters.md
@@ -117,7 +117,7 @@ Target component
 
 | Parameter name | Type | Value | Remarks |
 |---:| :---: | :--- |---|
-| `enabled` | Boolean(true/false) | Whether to enable the gRPC server. The default value is `true`. |
+| `enabled` | Boolean(true/false) | Whether to enable the gRPC server. The default value is `false`. |
 | `listen_address` | String | The address and port the server listens on. The default value is `0.0.0.0:52345` |
 | `endpoint` | String | Remote View of gRPC Server Endpoint URI. The default value is `dns:///localhost:52345` |
 | `secure` | Boolean (true/false) | Whether to enable secure ports for the gRPC server. The default value is false. |


### PR DESCRIPTION
統合gRPCサーバ (grpc_server.enabled) をデフォルト無効にする旨をdocs/config-parameters.mdに反映する。

https://github.com/project-tsurugi/tsurugi-issues/issues/1488