### PR TITLE
docs: update config-parameters.md at blob_relay section

### DIFF
--- a/docs/config-parameters.md
+++ b/docs/config-parameters.md
@@ -136,10 +136,8 @@ Target component
 |---:| :---: | :--- |---|
 | `enabled` | Boolean(true/false) | Whether to enable the BLOB relay service. The default value is `true` |
 | `session_store` | String | Session storage root directory. The default value is `var/blob/sessions` (relative path from $TSURUGI_HOME) |
-| `session_quota_size` | Integer | Session storage quota size. If not specified, unlimited. The default value is ` `, means not specified |
-| `local_enabled` | Boolean(true/false) | Whether to enable data transfer using the file system. The default value is `true`. |
-| `local_upload_copy_file` | Boolean(true/false)  | Whether to copy the original file when uploading using the file system. The default value is `false`. |
-| `stream_chunk_size` | Integer | Chunk size (in bytes) when transferring data in chunks during download in gRPC streaming. The default value is `1048576`. |
+| `session_quota_size` | Integer | Session storage quota size (in bytes). If not specified, unlimited. The default value is ` `, means not specified | If uploading a blob causes the session_store usage to exceed the `session_quota_size`, a RESOURCE_EXHAUSTED error is returned.
+| `stream_chunk_size` | Integer | Chunk size (in bytes) when transferring data in chunks  used for both downloads and uploads in gRPC streaming. The default value is `1048576`. |
 
 ## `glog` section
 


### PR DESCRIPTION
https://github.com/project-tsurugi/tsurugi-issues/issues/1401
* relayのlocal関係の設定はドキュメントから削除する
* session_quota_sizeの説明（単位、超えるとどうなるか）をドキュメントに記載
* chunk_sizeの説明、アップロードにも使う旨を追記