### PR TITLE
docs(sql): add DML table name aliases.

### DIFF
--- a/docs/sql-features.md
+++ b/docs/sql-features.md
@@ -277,7 +277,7 @@ CC_EXCEPTION (SQL-04000: serialization failed transaction:TID-000000000000003b s
 
 ```txt
 <update-statement>:
-  UPDATE <table-name> SET <set-clause> [, ...] [WHERE <value-expression>]
+  UPDATE <table-name> [ [AS] <alias-name> ] SET <set-clause> [, ...] [WHERE <value-expression>]
 
 <set-clause>:
   <column-name> = <value-expression>
@@ -287,7 +287,7 @@ CC_EXCEPTION (SQL-04000: serialization failed transaction:TID-000000000000003b s
 
 ```txt
 <delete-statement>:
-  DELETE FROM <table-name> [WHERE <value-expression>]
+  DELETE FROM <table-name> [ [AS] <alias-name> ] [WHERE <value-expression>]
 ```
 
 ## Queries

--- a/docs/sql-features.md
+++ b/docs/sql-features.md
@@ -277,7 +277,7 @@ CC_EXCEPTION (SQL-04000: serialization failed transaction:TID-000000000000003b s
 
 ```txt
 <update-statement>:
-  UPDATE <table-name> [ [AS] <alias-name> ] SET <set-clause> [, ...] [WHERE <value-expression>]
+  UPDATE <table-name> [ [AS] <relation-name> ] SET <set-clause> [, ...] [WHERE <value-expression>]
 
 <set-clause>:
   <column-name> = <value-expression>
@@ -287,7 +287,7 @@ CC_EXCEPTION (SQL-04000: serialization failed transaction:TID-000000000000003b s
 
 ```txt
 <delete-statement>:
-  DELETE FROM <table-name> [ [AS] <alias-name> ] [WHERE <value-expression>]
+  DELETE FROM <table-name> [ [AS] <relation-name> ] [WHERE <value-expression>]
 ```
 
 ## Queries


### PR DESCRIPTION
This pull request updates the SQL syntax documentation to clarify support for table aliases in `UPDATE` and `DELETE` statements. These changes make the documentation more accurate and helpful for users writing complex SQL queries.

**SQL syntax documentation improvements:**

* Added support for optional table aliases in the `UPDATE` statement syntax, allowing users to specify `[AS] <alias-name>` after the table name.
* Added support for optional table aliases in the `DELETE` statement syntax, allowing users to specify `[AS] <alias-name>` after the table name.